### PR TITLE
#13 Changed the cursor to not-allowed when the prop allowEdit is set to false

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -23,7 +23,6 @@ class App extends Component {
 
   render() {
     let attributes = {
-      name: 'name-two',
       id: 'name-two',
       disabled: true
     };
@@ -37,16 +36,23 @@ class App extends Component {
               <h4>type "text"</h4>
               <EasyEdit
                   type="text"
-                  value="Test Input Field"
+                  value="Can't click this"
                   onSave={App.onTest}
                   name="name-one"
                   allowEdit={false}
               />
               <EasyEdit
                   type="text"
+                  placeholder="I'm disabled!"
                   onSave={App.onTest}
                   onValidate={() => true}
                   attributes={attributes}
+              />
+              <EasyEdit
+                  type="text"
+                  value="Edit me!"
+                  onSave={App.onTest}
+                  name="name-one"
               />
               <h4>type "color"</h4>
               <EasyEdit

--- a/src/lib/EasyEdit.css
+++ b/src/lib/EasyEdit.css
@@ -19,6 +19,10 @@
 
 }
 
+.easy-edit-not-allowed{
+  cursor: not-allowed;
+}
+
 .easy-edit-checkbox-label {
   display: block;
 }

--- a/src/lib/EasyEdit.jsx
+++ b/src/lib/EasyEdit.jsx
@@ -177,9 +177,13 @@ export default class EasyEdit extends React.Component {
   }
 
   setCssClasses(existingClasses) {
-    return this.state.hover ?
-        'easy-edit-hover-on ' + existingClasses :
-        existingClasses;
+    if (!this.props.allowEdit) {
+      return'easy-edit-not-allowed ' + existingClasses;
+    } else if (this.state.hover) {
+      return 'easy-edit-hover-on ' + existingClasses;
+    } else {
+      return existingClasses;
+    }
   }
 
   static generateButton(ref, onClick, label, cssClass, name) {

--- a/src/lib/EasyEdit.jsx
+++ b/src/lib/EasyEdit.jsx
@@ -178,7 +178,7 @@ export default class EasyEdit extends React.Component {
 
   setCssClasses(existingClasses) {
     if (!this.props.allowEdit) {
-      return'easy-edit-not-allowed ' + existingClasses;
+      return 'easy-edit-not-allowed ' + existingClasses;
     } else if (this.state.hover) {
       return 'easy-edit-hover-on ' + existingClasses;
     } else {

--- a/src/lib/EasyEdit.test.js
+++ b/src/lib/EasyEdit.test.js
@@ -44,6 +44,12 @@ describe('EasyEdit', () => {
     expect((wrapper.state().editing)).toEqual(false);
   });
 
+  it('on hover - non editable should show a not-allowed cursor', () => {
+    wrapper.setProps({allowEdit: false});
+    wrapper.simulate('mouseEnter');
+    expect(wrapper.find('div.easy-edit-not-allowed')).toHaveLength(1);
+  });
+
   it('should populate the tempValue with the passed in value prop', () => {
     wrapper = shallow(
         <EasyEdit


### PR DESCRIPTION
Fix for #13 

Now if the `allowEdit` prop is set to `false` then the user will see a not-allowed cursor when they hover over the component

![vwqcqeD - Imgur](https://user-images.githubusercontent.com/1062121/54836987-40ba6c80-4cbd-11e9-8a33-4e654e55b26b.gif)
