### PR TITLE
placeholder elements are now accepted without printing annoying warnings

### DIFF
--- a/src/lib/EasyDropdown.jsx
+++ b/src/lib/EasyDropdown.jsx
@@ -33,7 +33,10 @@ EasyDropdown.propTypes = {
     PropTypes.string,
     PropTypes.number
   ]),
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
   attributes: PropTypes.object,
   cssClassPrefix: PropTypes.string,
   onFocus: PropTypes.func,

--- a/src/lib/EasyDropdown.test.js
+++ b/src/lib/EasyDropdown.test.js
@@ -29,9 +29,19 @@ describe('EasyDropdown', () => {
   it('should use the default placeholder', () => {
     expect(wrapper.find('select>option:first-child').text()).toEqual(Globals.DEFAULT_SELECT_PLACEHOLDER);
   });
-  it('should use the placeholder provided', () => {
+  it('should use the placeholder string provided', () => {
     wrapper.setProps({placeholder: "test"});
     expect(wrapper.find('select>option:first-child').text()).toEqual("test");
+  });
+  it('should use the placeholder element provided', () => {
+    let err = jest.spyOn(global.console, 'error');
+    wrapper.setProps({placeholder: <span>test</span>});
+
+    expect(wrapper.find('select>option:first-child').text()).toEqual("test");
+    expect(err).not.toHaveBeenCalled();
+
+    err.mockReset();
+    err.mockRestore();
   });
 
   it('should render 2 + 1 options including the disabled default one', () => {

--- a/src/lib/EasyEdit.jsx
+++ b/src/lib/EasyEdit.jsx
@@ -506,7 +506,10 @@ EasyEdit.propTypes = {
   ]),
   deleteButtonStyle: PropTypes.string,
   buttonsPosition: PropTypes.oneOf(['after', 'before']),
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
   onCancel: PropTypes.func,
   onDelete: PropTypes.func,
   onValidate: PropTypes.func,

--- a/src/lib/EasyEdit.test.js
+++ b/src/lib/EasyEdit.test.js
@@ -427,4 +427,20 @@ describe('EasyEdit', () => {
     wrapper.setProps({ value: "Updated Value", editMode: false });
     expect((wrapper.state().tempValue)).toEqual('Updated Value');
   });
+
+  it('should render a placeholder element', () => {
+    let err = jest.spyOn(global.console, 'error');
+    wrapper = shallow(
+        <EasyEdit
+            type="text"
+            onSave={saveFn}
+            onCancel={cancelFn}
+            placeholder={<span>test</span>}
+        />);
+    expect(wrapper.find('div.easy-edit-wrapper').text()).toEqual("test");
+    expect(err).not.toHaveBeenCalled();
+
+    err.mockReset();
+    err.mockRestore();
+  });
 });

--- a/src/lib/EasyInput.jsx
+++ b/src/lib/EasyInput.jsx
@@ -26,7 +26,10 @@ EasyInput.propTypes = {
   type: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   value: PropTypes.string,
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
   attributes: PropTypes.object,
   cssClassPrefix: PropTypes.string,
   onFocus: PropTypes.func,

--- a/src/lib/EasyInput.test.js
+++ b/src/lib/EasyInput.test.js
@@ -36,6 +36,16 @@ describe('EasyInput', () => {
     expect(wrapper.find('input').props().placeholder).toEqual('TEST');
   });
 
+  it('should render a placeholder element', () => {
+    let err = jest.spyOn(global.console, 'error');
+    wrapper.setProps({placeholder: <span>TEST</span>});
+    expect(wrapper.find('input').props().placeholder).toEqual(<span>TEST</span>);
+    expect(err).not.toHaveBeenCalled();
+
+    err.mockReset();
+    err.mockRestore();
+  });
+
   it('should not show a placeholder if there is a value available', () => {
     wrapper.setProps({value: 'Test'});
     expect(wrapper.find('input').props().value).toEqual('Test');

--- a/src/lib/EasyParagraph.jsx
+++ b/src/lib/EasyParagraph.jsx
@@ -23,7 +23,10 @@ const EasyParagraph = (props) => {
 EasyParagraph.propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.string,
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
   attributes: PropTypes.object,
   cssClassPrefix: PropTypes.string,
   onBlur: PropTypes.func,

--- a/src/lib/EasyParagraph.test.js
+++ b/src/lib/EasyParagraph.test.js
@@ -33,6 +33,17 @@ describe('EasyParagraph', () => {
     expect(wrapper.find('textarea').props().placeholder).toEqual('TEST');
   });
 
+  it('should use the provided placeholder element', () => {
+    let err = jest.spyOn(global.console, 'error');
+
+    wrapper.setProps({placeholder: <span>TEST</span>});
+    expect(wrapper.find('textarea').props().placeholder).toEqual(<span>TEST</span>);
+    expect(err).not.toHaveBeenCalled();
+
+    err.mockReset();
+    err.mockRestore();
+  });
+
   it('should not show a placeholder if there is a value available', () => {
     wrapper.setProps({value: 'Test'});
     expect(wrapper.find('textarea').props().value).toEqual('Test');


### PR DESCRIPTION
We are using react-easy-edit in a multi-language application and [lingui.js](https://github.com/lingui/js-lingui) does all the translation work.

lingui.js uses JSX elements (e.g. `<Trans>` ) to process any translated strings:

```
<EasyEdit
    type="text"
    placeholder={
        <Trans>
            Your CO<sub>2</sub> report
        </Trans>
    }
/>
```

This leads to warnings during testing and in production:

```
Warning: Failed prop type: Invalid prop `placeholder` of type `object` supplied to `EasyEdit`, expected `string`.
        at EasyEdit (/home/nschroeter/git/react-easy-edit/src/lib/EasyEdit.jsx:19:5)
```
        
As you can imagine, there will be literally thousands of warnings because the complete UI is being translated.

This PR should make it possible to pass JSX elements as placeholder values, including tests.
