### PR TITLE
Added display: inline-block to .easy-edit-wrapper

### DIFF
--- a/src/lib/EasyEdit.css
+++ b/src/lib/EasyEdit.css
@@ -39,3 +39,7 @@
 .easy-edit-validation-error {
   color: red;
 }
+
+.easy-edit-wrapper {
+  display: inline-block;
+}


### PR DESCRIPTION
Changing this default behaviour:

![ezgif-4-4d4228e110](https://user-images.githubusercontent.com/17275652/163562827-c56ecb29-22aa-4f3e-87db-a3c899585332.gif)

To something less surprising for users:

![ezgif-4-6e14d85093](https://user-images.githubusercontent.com/17275652/163562975-1a85c7de-8844-4743-b8e8-a895a3d3c5fd.gif)

