### PR TITLE
Add autofocus=false test for datalist

### DIFF
--- a/src/lib/EasyDatalist.test.js
+++ b/src/lib/EasyDatalist.test.js
@@ -67,4 +67,10 @@ describe('EasyDatalist Component', () => {
     const inputElement = screen.getByDisplayValue('Option 2');
     expect(inputElement).toBeInTheDocument();
   });
+
+  test('does not set autofocus attribute when autoFocus is false', () => {
+    render(<EasyDatalist {...defaultProps} attributes={{ autoFocus: false }} />);
+    const inputElement = screen.getByPlaceholderText('Enter value');
+    expect(inputElement).not.toHaveAttribute('autofocus');
+  });
 });


### PR DESCRIPTION
## Summary
- add a test verifying EasyDatalist skips autofocus when `autoFocus:false`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6880989cbd548329bfe2f24ba813233f